### PR TITLE
Added timer reset on custom training shot

### DIFF
--- a/MrSuluPlugin/MrSuluPlugin.cpp
+++ b/MrSuluPlugin/MrSuluPlugin.cpp
@@ -389,6 +389,13 @@ void MrSuluPlugin::OnCarSpawn(std::string eventName) {
 	*/
 }
 
+void MrSuluPlugin::OnFireBall(std::string eventName)
+{
+	timerIsReady();
+	timerStart();
+	timerDisplay("fire ball");
+}
+
 
 void MrSuluPlugin::OnTick(std::string funcName)
 {
@@ -587,7 +594,7 @@ void MrSuluPlugin::enable()
 	gameWrapper->HookEvent("Function TAGame.Car_TA.OnJumpPressed", bind(&MrSuluPlugin::OnJumpPressed, this, std::placeholders::_1));
 	gameWrapper->HookEvent("Function TAGame.Car_TA.OnJumpReleased", bind(&MrSuluPlugin::OnJumpReleased, this, std::placeholders::_1));
 	gameWrapper->HookEvent("Function TAGame.Car_TA.PostBeginPlay", bind(&MrSuluPlugin::OnCarSpawn, this, std::placeholders::_1));
-
+	gameWrapper->HookEvent("Function TAGame.GameEvent_GameEditor_TA.FireBalls", bind(&MrSuluPlugin::OnFireBall, this, std::placeholders::_1));
 
 	log("Warp speed MrSulu !!!");
 }
@@ -601,6 +608,7 @@ void MrSuluPlugin::disable()
 	gameWrapper->UnhookEvent("Function TAGame.Car_TA.OnJumpPressed");
 	gameWrapper->UnhookEvent("Function TAGame.Car_TA.OnJumpReleased");
 	gameWrapper->UnhookEvent("Function TAGame.Car_TA.PostBeginPlay");
+	gameWrapper->UnhookEvent("Function TAGame.GameEvent_GameEditor_TA.FireBalls");
 }
 
 float MrSuluPlugin::getCarTilt() {

--- a/MrSuluPlugin/MrSuluPlugin.h
+++ b/MrSuluPlugin/MrSuluPlugin.h
@@ -87,6 +87,7 @@ public:
 	void OnJumpPressed(std::string eventName);
 	void OnJumpReleased(std::string eventName);
 	void OnCarSpawn(std::string eventName);
+	void OnFireBall(std::string eventName);
 
 	void OnTick(std::string funcName);
 	void OnWorldLoad(std::string eventName);


### PR DESCRIPTION
Loving the plugin! One addition I thought of was automatic timer reset when doing custom training so you don't have to wait after a reset. I've added some functionality so the timer gets reset when the ball is fired in custom training by hooking ```Function TAGame.GameEvent_GameEditor_TA.FireBalls```

Edit: I just saw you mentioned this in the Discord so maybe you've already implemented it locally, in that case just ignore this PR